### PR TITLE
Fix path removal bug

### DIFF
--- a/app/lib/stores/files.ts
+++ b/app/lib/stores/files.ts
@@ -138,7 +138,7 @@ export class FilesStore {
         case 'remove_dir': {
           this.files.setKey(sanitizedPath, undefined);
 
-          for (const [direntPath] of Object.entries(this.files)) {
+          for (const [direntPath] of Object.entries(this.files.get())) {
             if (direntPath.startsWith(sanitizedPath)) {
               this.files.setKey(direntPath, undefined);
             }


### PR DESCRIPTION
## Summary
- fix deletion of nested file entries when a directory is removed

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871cace43b883308fdcf838aa299d72